### PR TITLE
Custom API operationIds

### DIFF
--- a/server/wupportal/src/main/java/de/codeschluss/portal/common/base/OperationIdBuilder.java
+++ b/server/wupportal/src/main/java/de/codeschluss/portal/common/base/OperationIdBuilder.java
@@ -1,0 +1,33 @@
+package de.codeschluss.portal.common.base;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spi.service.OperationBuilderPlugin;
+import springfox.documentation.spi.service.contexts.OperationContext;
+import springfox.documentation.swagger.common.SwaggerPluginSupport;
+
+@Component
+public class OperationIdBuilder implements OperationBuilderPlugin {
+
+	@Override
+	public void apply(OperationContext ctx) {
+		String call = StringUtils.capitalize(ctx.getName());
+		String tag = Arrays.stream(ctx.getGroupName().split("-"))
+				.map(StringUtils::capitalize)
+				.collect(Collectors.joining());
+
+		ctx.operationBuilder()
+				.codegenMethodNameStem(StringUtils.uncapitalize(tag + call));
+	}
+
+	@Override
+	public boolean supports(DocumentationType delimiter) {
+		return SwaggerPluginSupport.pluginDoesApply(delimiter);
+	}
+
+}


### PR DESCRIPTION
Implement OperationBuilderPlugin to customize the operationIds used in the api-docs.